### PR TITLE
build: add patch for js-waku not found

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -9,15 +9,9 @@ module.exports = {
   globals: {
     "ts-jest": {
       tsconfig: "tsconfig.tests.json"
-    },
+    }
   },
-  roots: [
-    "<rootDir>"
-  ],
-  modulePaths: [
-    "<rootDir>"
-  ],
-  moduleDirectories: [
-    "node_modules"
-  ]
+  roots: ["<rootDir>"],
+  modulePaths: ["<rootDir>"],
+  moduleDirectories: ["node_modules"]
 };

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "lint": "eslint --ignore-path .gitignore --ext .js,.ts .",
     "lint:fix": "npm run lint -- --fix",
     "prettier": "prettier --write .",
-    "test": "jest"
+    "test": "jest",
+    "postinstall": "patch-package"
   },
   "author": "Boson Protocol",
   "license": "Apache-2.0",
@@ -38,6 +39,7 @@
     "eslint-config-prettier": "^8.4.0",
     "eslint-plugin-prettier": "^4.0.0",
     "jest": "^28.1.3",
+    "patch-package": "^6.4.7",
     "prettier": "^2.6.2",
     "rimraf": "^3.0.2",
     "ts-jest": "^28.0.7",

--- a/patches/js-waku+0.24.0.patch
+++ b/patches/js-waku+0.24.0.patch
@@ -1,0 +1,14 @@
+diff --git a/node_modules/js-waku/package.json b/node_modules/js-waku/package.json
+index c5ade17..dfb4652 100644
+--- a/node_modules/js-waku/package.json
++++ b/node_modules/js-waku/package.json
+@@ -8,7 +8,8 @@
+   "exports": {
+     "node": {
+       "module": "./build/esm/index.js",
+-      "import": "./build/main/index.js"
++      "import": "./build/main/index.js",
++      "require": "./build/main/index.js"
+     },
+     "default": "./build/main/index.js"
+   },


### PR DESCRIPTION
When running the test with `jest`, it errored with
```
Cannot find module 'js-waku' from 'node_modules/@xmtp/xmtp-js/dist/cjs/src/utils.js'
```

The problem seems to be this issue
https://github.com/status-im/js-waku/issues/770.

Until this is resolved, we use a local patch as this only occurs when running tests.