### PR TITLE
refactor: change fixed esm to default import

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import {
   ListMessagesOptions,
   Message,
   TextCodec
-} from "@xmtp/xmtp-js/dist/esm";
+} from "@xmtp/xmtp-js";
 import { Signer } from "ethers";
 import { XmtpClient, XmtpEnv } from "./xmtp/client";
 import { BosonCodec, ContentTypeBoson } from "./xmtp/codec/boson-codec";
@@ -131,6 +131,12 @@ export class BosonXmtpClient extends XmtpClient {
           message
         )) as MessageObject;
         if (matchThreadIds(decodedMessage.threadId, threadId)) {
+          if (!message.contentType) {
+            throw new Error("Received message does not have contentType");
+          }
+          if (!message.recipientAddress) {
+            throw new Error("Received message does not have recipientAddress");
+          }
           const messageData: MessageData = {
             authorityId: message.contentType.authorityId,
             sender: message.senderAddress,
@@ -170,6 +176,14 @@ export class BosonXmtpClient extends XmtpClient {
       recipient,
       fallBackDeepLink
     );
+
+    if (!message.senderAddress) {
+      throw new Error("Sent message does not have senderAddress");
+    }
+
+    if (!message.recipientAddress) {
+      throw new Error("Sent message does not have recipientAddress");
+    }
 
     return {
       authorityId: getAuthorityId(this.envName),

--- a/src/xmtp/client.ts
+++ b/src/xmtp/client.ts
@@ -6,7 +6,7 @@ import {
   Message,
   SendOptions,
   TextCodec
-} from "@xmtp/xmtp-js/dist/esm";
+} from "@xmtp/xmtp-js";
 import { MessageType } from "../util/v0.0.1/definitions";
 import { BosonCodec, ContentTypeBoson } from "./codec/boson-codec";
 import {

--- a/src/xmtp/codec/boson-codec.ts
+++ b/src/xmtp/codec/boson-codec.ts
@@ -1,8 +1,4 @@
-import {
-  ContentTypeId,
-  ContentCodec,
-  EncodedContent
-} from "@xmtp/xmtp-js/dist/esm";
+import { ContentTypeId, ContentCodec, EncodedContent } from "@xmtp/xmtp-js";
 import { getAuthorityId } from "../../util/v0.0.1/functions";
 
 /**


### PR DESCRIPTION
I had to remove the /esm imports so it resolves automatically to either esm or cjs because metaseller needs cjs imports.