### PR TITLE
feat: add more message types

### DIFF
--- a/src/util/v0.0.1/definitions.ts
+++ b/src/util/v0.0.1/definitions.ts
@@ -1,6 +1,13 @@
 export const version = "0.0.1";
 export const domain = "bosonprotocol.io";
 
+export enum SupportedFileMimeTypes {
+  PNG = "image/png",
+  JPEG = "image/jpeg",
+  GIF = "image/gif",
+  PDF = "application/pdf"
+}
+
 export interface ThreadObject {
   threadId: ThreadId;
   counterparty: string;
@@ -25,13 +32,23 @@ export interface MessageObject {
   threadId: ThreadId;
   contentType: MessageType;
   version: typeof version;
-  content: StringContent | FileContent | ProposalContent;
+  content:
+    | StringContent
+    | FileContent
+    | ProposalContent
+    | StringIconContent
+    | AcceptProposalContent
+    | EscalateDisputeContent;
 }
 
 export enum MessageType {
   String = "STRING",
   File = "FILE",
-  Proposal = "PROPOSAL"
+  Proposal = "PROPOSAL",
+  CounterProposal = "COUNTER_PROPOSAL",
+  AcceptProposal = "ACCEPT_PROPOSAL",
+  StringIcon = "STRING_ICON",
+  EscalateDispute = "ESCALATE_DISPUTE"
 }
 
 export interface StringContent {
@@ -47,13 +64,6 @@ export interface FileContent {
   };
 }
 
-export enum SupportedFileMimeTypes {
-  PNG = "image/png",
-  JPEG = "image/jpeg",
-  GIF = "image/gif",
-  PDF = "application/pdf"
-}
-
 export interface ProposalContent {
   value: {
     title: string;
@@ -67,4 +77,32 @@ export interface ProposalItem {
   type: string;
   percentageAmount: string;
   signature: string;
+}
+
+export interface StringIconContent {
+  value: {
+    icon: string;
+    heading: string;
+    body: string;
+  };
+}
+
+export interface AcceptProposalContent {
+  value: {
+    title: string;
+    proposal: ProposalItem;
+    icon: string;
+    heading: string;
+    body: string;
+  };
+}
+
+export interface EscalateDisputeContent {
+  value: {
+    title: string;
+    description: string;
+    disputeResolverInfo: string[];
+    heading: string;
+    body: string;
+  };
 }


### PR DESCRIPTION
New message type to:

- send counter proposals:

![image](https://github.com/bosonprotocol/chat-sdk/assets/102516373/7cb3aab5-84a7-44b8-9de2-d7a31aea2e34)

- accept proposals

![image](https://github.com/bosonprotocol/chat-sdk/assets/102516373/ec36110e-61df-4da4-ae52-470db87af834)


- send messages with icons

![image](https://github.com/bosonprotocol/chat-sdk/assets/102516373/2cba17e2-f2b9-41cd-af4d-858a3ff462ba)


- escalate disputes

![image](https://github.com/bosonprotocol/chat-sdk/assets/102516373/cd5d3799-6b36-48d5-b4f0-63adcff0dcbe)

