### PR TITLE
chore: change exports so mcp is not exported in @bosonprotocol/chat-s…

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,2 @@
 export * from "./browser/index.js";
 export * from "./common/index.js";
-export * from "./mcp/index.js";


### PR DESCRIPTION
…dk as before so it doesnt crash for browsers