### PR TITLE
docs(mcp): document private-key trust model and self-hosting requirements (#100)

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,28 @@ await client.encodeAndSendMessage(messageObj, recipient);</pre>
 </ul>
 
 <hr>
+<h2>MCP server &amp; client</h2>
+
+This package also ships a [Model Context Protocol](https://modelcontextprotocol.io) (MCP)
+server and client (under `src/mcp/`) that expose Boson XMTP messaging as tools — initialise
+an XMTP client, read threads, send messages, and revoke installations — so AI agents can use
+them. It is published with the `boson-xmtp-mcp-server` binary and supports two transports:
+
+<ul>
+    <li><b>stdio</b> — the server runs as a local subprocess on the end user's machine (recommended).</li>
+    <li><b>HTTP</b> — a long-running server that <i>you</i> host on infrastructure you control.</li>
+</ul>
+
+> ⚠️ **Security: the MCP server acts on behalf of a wallet and needs its private key.**
+> Anyone who can reach the server or read its logs/memory can sign as that wallet. **Run it
+> locally (stdio) or self-host it privately — never point a client at a shared/public server,
+> and never expose it unauthenticated.** Provide the key as a hosting secret, never in client
+> requests or committed files.
+>
+> Read [`SECURITY.md`](SECURITY.md) and the [self-hosting guide](docs/mcp-self-hosting.md)
+> before running or deploying the MCP server.
+
+<hr>
 <h2>Local Development</h2>
 <ul>
     <li>Build</li>

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,7 +5,6 @@
 Please report security vulnerabilities **privately** — do not open a public GitHub issue.
 
 - Email: **security@bosonprotocol.io**
-- Or reach the team privately via the [Boson Protocol Discord](https://discord.com/invite/QSdtKRaap6).
 
 We will acknowledge your report and work with you on a coordinated disclosure.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,70 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please report security vulnerabilities **privately** — do not open a public GitHub issue.
+
+- Email: **security@bosonprotocol.io**
+- Or reach the team privately via the [Boson Protocol Discord](https://discord.com/invite/QSdtKRaap6).
+
+We will acknowledge your report and work with you on a coordinated disclosure.
+
+---
+
+## MCP server: wallet private-key trust model
+
+> **Read this before running or deploying the MCP server.**
+
+The Boson XMTP **MCP server acts on behalf of a wallet**. To initialise an XMTP client,
+read threads, send messages, and revoke installations, it needs the wallet's **private
+key**. Concretely, the server turns the key into an `ethers.Wallet` and signs with it.
+
+This has a direct security consequence:
+
+> **Anyone who can reach the MCP server, read its memory, or read its logs can sign as
+> that wallet** — send messages, revoke installations, and otherwise act as the wallet
+> owner. The private key is the wallet. Treat the MCP server as a piece of wallet
+> infrastructure, not as a shared API.
+
+### Hard rules
+
+1. **Run the server locally, or self-host it on infrastructure you control.**
+   - Preferred: **stdio** transport, where the server runs as a local subprocess on the
+     end user's machine.
+   - Acceptable: **HTTP** transport that **you** host, on infrastructure **you** are
+     responsible for, behind your own authentication.
+2. **Never point a client at a shared or third-party MCP server**, and **never expose the
+   server publicly or unauthenticated.** A public server that holds (or receives) private
+   keys is a custodial service for other people's wallets.
+3. **One server instance per wallet.** A single instance should be bound to a single
+   wallet. Do not operate a multi-tenant server that handles many users' keys.
+4. **Provide the key as a hosting secret**, e.g. an environment variable or secret
+   manager — see [`docs/mcp-self-hosting.md`](docs/mcp-self-hosting.md). **Never**:
+   - commit the key to git (including in `mcpServer.json` or `.env` files),
+   - paste it into shared chats, tickets, or logs,
+   - send it to a server you do not control.
+5. **Use a dedicated, low-value wallet** for messaging where possible, and rotate the key
+   if you suspect exposure.
+
+### Known limitation (being addressed)
+
+The current code transmits the private key from the client to the server **as a tool-call
+argument on every request**, and the server can be deployed as a public, unauthenticated,
+multi-tenant HTTP service. This means the key can travel over the network and appear in
+logs. Until the hardening below lands, the **only** safe configuration is a **local stdio
+server** (or a strictly private, self-hosted, single-wallet HTTP server that you control).
+
+We are moving to an **environment-secret model**, where the server reads the key once at
+startup from a hosting secret (an environment variable) and the client never transmits it.
+Tracking issues:
+
+- Documentation (this policy and the self-hosting guide): **#100**
+- Code changes (key from environment, removal of the public deployment): **#101**
+
+---
+
+## Scope
+
+This policy covers the `@bosonprotocol/chat-sdk` package, including the MCP server and
+client under `src/mcp/`. For vulnerabilities in the wider Boson Protocol, see the
+[Boson Protocol](https://bosonprotocol.io) security channels.

--- a/docs/mcp-self-hosting.md
+++ b/docs/mcp-self-hosting.md
@@ -63,9 +63,9 @@ configuration) through the spawned process's environment — see the
 {
   "mcpServers": {
     "boson-xmtp-mcp-server-stdio": {
-      "command": "node",
       "args": ["/your-path-to/chat-sdk/dist/mcp/server/index.js"],
       "env": {
+        "START": "true",
         "BOSON_XMTP_PRIVATE_KEY": "<your wallet private key>"
       }
     }

--- a/docs/mcp-self-hosting.md
+++ b/docs/mcp-self-hosting.md
@@ -1,0 +1,114 @@
+# Self-hosting the Boson XMTP MCP server
+
+The MCP server signs and acts on behalf of a wallet, so **how you host it is a security
+decision**. Read [`SECURITY.md`](../SECURITY.md) first — this guide is the practical
+companion to it.
+
+The golden rule: **the server holds the keys to a wallet, so run it like wallet
+infrastructure** — locally, or self-hosted on infrastructure you control, one wallet per
+instance, key supplied as a secret.
+
+---
+
+## Choose a transport
+
+| Transport | Where it runs | Use when |
+| --------- | ------------- | -------- |
+| **stdio** (recommended) | A local subprocess on the **end user's machine**, spawned by the client. | Default. The key never leaves the user's machine. |
+| **HTTP** | A server **you** host and are responsible for, behind your own auth. | You need a long-running service. Must be private and single-wallet. |
+
+> ⚠️ **Never** run a shared, public, or unauthenticated HTTP server that holds private
+> keys, and never point your client at a third-party MCP server. That makes it a custodial
+> service for other people's wallets.
+
+---
+
+## Provide the private key as a secret
+
+Each server instance is bound to **one** wallet. Supply that wallet's key through the
+**hosting environment** — an environment variable or a secret manager — not through client
+requests or committed files.
+
+The target environment variable is:
+
+```
+BOSON_XMTP_PRIVATE_KEY=<the wallet private key>
+```
+
+Do **not**:
+
+- commit the key to git (this includes `mcpServer.json` and any `.env` file — keep them
+  out of version control),
+- log it or paste it into shared chats/tickets,
+- send it to a server you do not control.
+
+Prefer a **dedicated, low-value wallet** for messaging, and rotate the key if you suspect
+exposure.
+
+> **Current limitation:** at the time of writing, the server still receives the key as a
+> per-request tool argument and does not yet read `BOSON_XMTP_PRIVATE_KEY` itself (tracked
+> in **#101**). Until that lands, the safe configuration is a **local stdio server**, or a
+> strictly private, self-hosted, single-wallet HTTP server. This guide documents the
+> intended secret-based model so your setup is ready for it.
+
+---
+
+## Running with stdio (recommended)
+
+The client spawns the server as a subprocess. Supply the key (and any non-default
+configuration) through the spawned process's environment — see the
+[`mcpServer.example.json`](../mcpServer.example.json) template:
+
+```jsonc
+{
+  "mcpServers": {
+    "boson-xmtp-mcp-server-stdio": {
+      "command": "node",
+      "args": ["/your-path-to/chat-sdk/dist/mcp/server/index.js"],
+      "env": {
+        "BOSON_XMTP_PRIVATE_KEY": "<your wallet private key>"
+      }
+    }
+  }
+}
+```
+
+Keep this file **out of version control** when it contains a real key.
+
+---
+
+## Running over HTTP (self-hosted only)
+
+If you must run an HTTP server, treat it as private infrastructure:
+
+- **Bind to `127.0.0.1`** by default. Only bind `0.0.0.0` when the server sits behind your
+  own authenticated reverse proxy on a network you control. Do not expose it directly to
+  the internet.
+- **Never deploy with unauthenticated public access.** Put authentication in front of it.
+- **One wallet per instance.** Configure that instance's `BOSON_XMTP_PRIVATE_KEY` as a
+  secret in your platform (e.g. a secret manager / runtime secret), not baked into the
+  image or committed to the repo.
+- **Restrict origins/hosts.** The server honours `ALLOWED_HOSTS` (comma-separated) for
+  Host/Origin validation; set it to the hosts you actually use.
+
+### Docker
+
+The included `Dockerfile` / `docker-compose.yml` are a starting point for **local /
+private** use. When you run them:
+
+- supply `BOSON_XMTP_PRIVATE_KEY` as a runtime secret (e.g. an env file that is **not**
+  committed, or your orchestrator's secret mechanism),
+- prefer binding to `127.0.0.1` (or keep `0.0.0.0` only when the container is reached
+  exclusively through your own authenticated proxy).
+
+---
+
+## Checklist before you expose anything
+
+- [ ] The key is provided as a hosting secret, not a client request or committed file.
+- [ ] This instance is bound to exactly one wallet.
+- [ ] stdio is local to the user, or the HTTP server is private and authenticated.
+- [ ] No public, unauthenticated endpoint holds or receives the key.
+- [ ] A dedicated, low-value wallet is used where possible.
+
+See also: [`SECURITY.md`](../SECURITY.md).

--- a/mcpServer.example.json
+++ b/mcpServer.example.json
@@ -2,7 +2,15 @@
   "mcpServers": {
     "boson-xmtp-mcp-server-stdio": {
       "command": "node",
-      "args": ["/your-path-to/chat-sdk/dist/mcp/server/index.js"]
+      "args": ["/your-path-to/chat-sdk/dist/mcp/server/index.js"],
+      "env": {
+        "BOSON_XMTP_PRIVATE_KEY": "<your-wallet-private-key>"
+      }
+    },
+    "boson-xmtp-mcp-server-http": {
+      "type": "streamable-http",
+      "url": "http://127.0.0.1:3000/mcp",
+      "note": "Self-hosted only. The remote server must hold its own BOSON_XMTP_PRIVATE_KEY secret (configured in its hosting environment); the client never sends the key over HTTP. Never point this at a shared/public/unauthenticated server."
     }
   }
 }

--- a/mcpServer.example.json
+++ b/mcpServer.example.json
@@ -4,6 +4,7 @@
       "command": "node",
       "args": ["/your-path-to/chat-sdk/dist/mcp/server/index.js"],
       "env": {
+        "START": "true",
         "BOSON_XMTP_PRIVATE_KEY": "<your-wallet-private-key>"
       }
     },


### PR DESCRIPTION
## What & why

Step 1 (short term) of the MCP wallet private-key security work: **documentation only, no
code or deployment changes.**

The MCP server signs on behalf of a wallet and needs its private key, but nothing in the
docs warned operators about the trust model or the hosting implications. This PR makes the
risk and the hosting rules explicit so no one runs a shared/public instance or sends keys
over the network — ahead of the code hardening tracked in #101.

## Changes

- **`SECURITY.md`** (new): trust model, hard hosting rules (run locally / self-host only,
  one wallet per instance, key as a hosting secret), the current per-request-key limitation,
  and a responsible-disclosure contact.
- **`docs/mcp-self-hosting.md`** (new): practical stdio-vs-HTTP guide, supplying
  `BOSON_XMTP_PRIVATE_KEY` as a secret, and a pre-exposure checklist.
- **`README.md`**: new "MCP server & client" section with a prominent security callout
  linking to the policy and the guide (the README previously had no MCP content).
- **`mcpServer.example.json`**: env-secret block for the stdio server and a self-hosted
  HTTP example noting the remote owns its own secret.

## Notes for reviewers

- The **disclosure contact** in `SECURITY.md` is a placeholder (`security@bosonprotocol.io`
  + Discord) — please confirm or replace with the real channel.
- The **HTTP config example** uses `"type": "streamable-http"` + `"url"` plus a `"note"`
  field to convey "remote owns its own secret" in strict JSON — adjust if your inspector
  config expects a different discriminator.
- Docs intentionally describe the **target** env-secret model and flag the current
  limitation; the actual code change (server reads `BOSON_XMTP_PRIVATE_KEY`, removal of the
  public deployment) is **#101**.

Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)
